### PR TITLE
Client Data Persistence and Practice Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .next
 next-env.d.ts
 .idea
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ To run the transformation script, use `npx ts-node --esm scripts/transform.ts`.
 
 ## Debugging Query Parameters
 
-To specify a particular league, day, and question index, add to the query params like so: `?league=80&day=3&index=2`. If valid, these will be used to load the question. Currently for debugging only.
+To specify a particular league, day, and question index, add to the query params like so: `?league=80&day=3&index=2`. If valid, these will be used to load the question. If any are not valid or not specified, random values are chosen. Currently for debugging only.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## Transformation Script
 
 To run the transformation script, use `npx ts-node --esm scripts/transform.ts`.
+
+## Debugging Query Parameters
+
+To specify a particular league, day, and question index, add to the query params like so: `?league=80&day=3&index=2`. If valid, these will be used to load the question. Currently for debugging only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7253,6 +7253,126 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.3.tgz",
+      "integrity": "sha512-Mi8xJWh2IOjryAM1mx18vwmal9eokJ2njY4nDh04scy37F0LEGJ/diL6JL6kTXi0UfUCGbMsOItf7vpReNiD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.3.tgz",
+      "integrity": "sha512-aBvtry4bxJ1xwKZ/LVPeBGBwWVwxa4bTnNkRRw6YffJnn/f4Tv4EGDPaVeYHZGQVA56wsGbtA6nZMuWs/EIk4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.3.tgz",
+      "integrity": "sha512-krT+2G3kEsEUvZoYte3/2IscscDraYPc2B+fDJFipPktJmrv088Pei/RjrhWm5TMIy5URYjZUoDZdh5k940Dyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.3.tgz",
+      "integrity": "sha512-AMdFX6EKJjC0G/CM6hJvkY8wUjCcbdj3Qg7uAQJ7PVejRWaVt0sDTMavbRfgMchx8h8KsAudUCtdFkG9hlEClw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.3.tgz",
+      "integrity": "sha512-jySgSXE48shaLtcQbiFO9ajE9mqz7pcAVLnVLvRIlUHyQYR/WyZdK8ehLs65Mz6j9cLrJM+YdmdJPyV4WDaz2g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.3.tgz",
+      "integrity": "sha512-5DxHo8uYcaADiE9pHrg8o28VMt/1kR8voDehmfs9AqS0qSClxAAl+CchjdboUvbCjdNWL1MISCvEfKY2InJ3JA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.3.tgz",
+      "integrity": "sha512-LaqkF3d+GXRA5X6zrUjQUrXm2MN/3E2arXBtn5C7avBCNYfm9G3Xc646AmmmpN3DJZVaMYliMyCIQCMDEzk80w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.3.tgz",
+      "integrity": "sha512-jglUk/x7ZWeOJWlVoKyIAkHLTI+qEkOriOOV+3hr1GyiywzcqfI7TpFSiwC7kk1scOiH7NTFKp8mA3XPNO9bDw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "llama-trainer",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.14",
+        "@heroicons/react": "^2.0.18",
         "@types/node": "20.2.3",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
@@ -732,6 +734,29 @@
       "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.14.tgz",
+      "integrity": "sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4936,14 +4961,6 @@
       "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "deploy": "next build && touch out/.nojekyll && git add out/ && git commit -m \"Deploy\" && git subtree push --prefix out origin gh-pages"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.14",
+    "@heroicons/react": "^2.0.18",
     "@types/node": "20.2.3",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/src/app/LocalDatabase.ts
+++ b/src/app/LocalDatabase.ts
@@ -1,0 +1,74 @@
+import {QuestionId} from "@/app/questionId";
+import {AnswerRatio} from "@/app/answerRatio";
+
+export class LocalDatabase {
+    private static LOCAL_STORAGE_KEY = "answer-history"
+
+    private database: Map<string, AnswerRatio>
+    private storage: Storage;
+
+    constructor(storage: Storage) {
+        this.storage = storage
+        this.database = this.deserializeFromStorage()
+    }
+
+    markAnswerAsCorrect(questionId: QuestionId): AnswerRatio {
+        let statistics = this.getStatisticsForQuestion(questionId)
+        statistics.correct += 1
+        statistics.total += 1
+
+        this.setStatisticsForQuestion(questionId, statistics)
+
+        return statistics
+    }
+
+    markAnswerAsIncorrect(questionId: QuestionId): AnswerRatio {
+        let statistics = this.getStatisticsForQuestion(questionId)
+        statistics.total += 1
+
+        this.setStatisticsForQuestion(questionId, statistics)
+
+        return statistics
+    }
+
+    getStatisticsForQuestion(questionId: QuestionId) {
+        return this.database.get(this.serializeQuestionId(questionId)) ?? { correct: 0, total: 0 }
+    }
+
+    reset() {
+        this.database = new Map()
+        this.serializeToStorage()
+    }
+
+    private setStatisticsForQuestion(questionId: QuestionId, newStatistics: AnswerRatio) {
+        this.database.set(this.serializeQuestionId(questionId), newStatistics)
+        this.serializeToStorage()
+    }
+
+    private serializeQuestionId(questionId: QuestionId): string {
+        return `${questionId.league}-${questionId.day}-${questionId.index}`;
+    }
+
+    private deserializeQuestionId(questionId: string): QuestionId {
+        const split = questionId.split("-")
+        return {
+            league: parseInt(split[0], 10),
+            day: parseInt(split[1], 10),
+            index: parseInt(split[2], 10)
+        }
+    }
+
+    private serializeToStorage() {
+        const data = JSON.stringify(Object.fromEntries(this.database))
+        this.storage.setItem(LocalDatabase.LOCAL_STORAGE_KEY, data)
+    }
+
+    private deserializeFromStorage(): Map<string, AnswerRatio> {
+        const json = this.storage.getItem(LocalDatabase.LOCAL_STORAGE_KEY)
+        if (json === null) {
+            return new Map()
+        } else {
+            return new Map(Object.entries(JSON.parse(json)))
+        }
+    }
+}

--- a/src/app/answerRatio.tsx
+++ b/src/app/answerRatio.tsx
@@ -1,0 +1,4 @@
+export interface AnswerRatio {
+    correct: number;
+    total: number;
+}

--- a/src/app/gameMode.ts
+++ b/src/app/gameMode.ts
@@ -1,0 +1,4 @@
+export enum GameMode {
+    REGULAR,
+    PRACTICE
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import type {NextPage} from "next";
+import { Dialog, Transition } from '@headlessui/react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import React, {useEffect, useRef, useState} from "react";
 import {ReadonlyURLSearchParams, useSearchParams} from "next/navigation";
 import {checkAnswer} from "@/utils/answerChecker";
 import {QuestionId} from "@/app/questionId";
 import {AnswerRatio} from "@/app/answerRatio";
 import {LocalDatabase} from "@/app/LocalDatabase";
+import ResetAnswerHistoryConfirmation from "@/app/resetAnswerHistoryConfirmation";
 
 function randomInt(min: number, max: number) {
   // min and max included
@@ -61,7 +64,7 @@ const Home: NextPage = () => {
   const [e, setE] = useState<string>(" ");
   const [input, setInput] = useState<string>("");
   const [correct, setCorrect] = useState<boolean>(true);
-  const [hasConfirmedReset, setHasConfirmedReset] = useState<boolean>(false);
+  const [isConfirmingReset, setIsConfirmingReset] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   function inputClassName() {
@@ -192,7 +195,7 @@ const Home: NextPage = () => {
   };
 
   const resetAnswerHistory = () => {
-
+    localDatabase.reset()
   }
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -223,6 +226,13 @@ const Home: NextPage = () => {
 
   return (
     <div className="container mx-auto">
+      <ResetAnswerHistoryConfirmation
+          isOpen={isConfirmingReset}
+          onConfirm={() => {
+            resetAnswerHistory()
+            setIsConfirmingReset(false)
+          }}
+          onCancel={() => setIsConfirmingReset(false)}/>
       <div className="flex flex-row items-start gap-4 flex-wrap md:flex-nowrap">
         <div className="container basis-full shrink-0 md:basis-2/3">
           <div className="card bg-base-100 shadow">
@@ -302,7 +312,7 @@ const Home: NextPage = () => {
             <table className="table table-compact text-center">
               <thead>
                 <tr>
-                  <th>A</th>
+                  <th style={{zIndex: 10}}>A</th>
                   <th>B</th>
                   <th>C</th>
                   <th>D</th>
@@ -325,7 +335,7 @@ const Home: NextPage = () => {
             <table className="table table-compact text-center">
               <thead>
                 <tr>
-                  <th>Category</th>
+                  <th style={{zIndex: 10}}>Category</th>
                   <th>Score</th>
                 </tr>
               </thead>
@@ -347,8 +357,9 @@ const Home: NextPage = () => {
             <h3 className="card-title">Settings</h3>
               <div>
                 <button
-                    className="btn btn-warning"
-                    onClick={HandleNext}
+                    type="button"
+                    className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                    onClick={() => setIsConfirmingReset(true)}
                 >
                   Reset Answer History
                 </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,6 @@ function randomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-const params = new Proxy(new URLSearchParams(window.location.search), {
-  get: (searchParams, prop) => searchParams.get(prop.toString()),
-});
-
 let currentData: Question;
 let isShowingAnswer = true;
 let [minLeague, maxLeague] = [60, 96];

--- a/src/app/questionId.ts
+++ b/src/app/questionId.ts
@@ -1,0 +1,5 @@
+export interface QuestionId {
+    league: number;
+    day: number;
+    index: number;
+}

--- a/src/app/resetAnswerHistoryConfirmation.tsx
+++ b/src/app/resetAnswerHistoryConfirmation.tsx
@@ -1,0 +1,87 @@
+import { Fragment, useRef, useState } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+
+interface ResetAnswerHistoryConfirmationProps {
+    isOpen: boolean,
+    onConfirm: () => void
+    onCancel: () => void
+}
+export default function ResetAnswerHistoryConfirmation({onConfirm, onCancel, isOpen} : ResetAnswerHistoryConfirmationProps) {
+    const cancelButtonRef = useRef(null)
+
+    return (
+        <Transition.Root show={isOpen} as={Fragment}>
+            <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={onCancel}>
+                <Transition.Child
+                    as={Fragment}
+                    enter="ease-out duration-300"
+                    enterFrom="opacity-0"
+                    enterTo="opacity-100"
+                    leave="ease-in duration-200"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
+                >
+                    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+                </Transition.Child>
+
+                <div className="fixed inset-0 z-10 overflow-y-auto">
+                    <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                        <Transition.Child
+                            as={Fragment}
+                            enter="ease-out duration-300"
+                            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                            enterTo="opacity-100 translate-y-0 sm:scale-100"
+                            leave="ease-in duration-200"
+                            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+                            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                        >
+                            <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                                <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                                    <div className="sm:flex sm:items-start">
+                                        <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                                            <ExclamationTriangleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
+                                        </div>
+                                        <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                                            <Dialog.Title as="h3" className="text-base font-semibold leading-6 text-gray-900">
+                                                Reset answer history?
+                                            </Dialog.Title>
+                                            <div className="mt-2">
+                                                <p className="text-sm text-gray-500">
+                                                    Are you sure you want to reset your answer history? All of your data will be permanently
+                                                    removed. This action cannot be undone.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                                    <button
+                                        type="button"
+                                        className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                                        onClick={() => {
+                                            onConfirm()
+                                        }
+                                    }
+                                    >
+                                        Reset History
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                                        onClick={() => {
+                                            onCancel()
+                                        } }
+                                        ref={cancelButtonRef}
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </Dialog.Panel>
+                        </Transition.Child>
+                    </div>
+                </div>
+            </Dialog>
+        </Transition.Root>
+    )
+}


### PR DESCRIPTION
Also contains all changes in https://github.com/berrybus/llama-trainer/pull/5

Stores data on the client persisting across sessions

Adds ability to clear stored data with confirmation modal
![Screen Shot 2023-05-29 at 02 08 35](https://github.com/berrybus/llama-trainer/assets/3794866/9d6353e6-be4c-4039-abb6-b6496cfddc6c)

Allows switching to practice mode - if you have 20 or more questions with < 50% accuracy you can practice those questions

Added percentages to total score

Added lifetime stats section for unique questions answered 


